### PR TITLE
Track UTM parameters during Telegram registration

### DIFF
--- a/app/Http/Controllers/TelegramController.php
+++ b/app/Http/Controllers/TelegramController.php
@@ -99,6 +99,10 @@ class TelegramController extends Controller
             ]);
         }
 
+        if ($utm = Cache::pull("utm_tg_{$telegramId}")) {
+            $user->update($utm);
+        }
+
         $token = $user->createToken('web');
 
         return response()->json([

--- a/app/Http/Controllers/UtmController.php
+++ b/app/Http/Controllers/UtmController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class UtmController extends Controller
+{
+    public function store(Request $request)
+    {
+        $token = Str::random(32);
+
+        $data = [
+            'utm_source'   => $request->get('utm_source'),
+            'utm_medium'   => $request->get('utm_medium'),
+            'utm_campaign' => $request->get('utm_campaign'),
+            'utm_content'  => $request->get('utm_content'),
+            'utm_term'     => $request->get('utm_term'),
+        ];
+
+        Cache::put("utm_{$token}", $data, now()->addDay());
+
+        return response()->json(['token' => $token]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,7 +36,12 @@ class User extends Authenticatable
         'is_frozen',
         'tg_token',
         'comment',
-        'reset_token'
+        'reset_token',
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_content',
+        'utm_term'
     ];
 
     /**

--- a/app/Services/TelegramService.php
+++ b/app/Services/TelegramService.php
@@ -109,6 +109,32 @@ class TelegramService
                             $forSeller
                         );
                     }
+                    if (str_starts_with($startPayload, 'utm')) {
+                        $utmToken = str_replace('utm', '', $startPayload);
+                        if ($utm = Cache::pull("utm_{$utmToken}")) {
+                            Cache::put("utm_tg_{$chatId}", $utm, now()->addDays(10));
+                        }
+
+                        $keyboard = [
+                            'keyboard' => [
+                                [
+                                    [
+                                        'text' => '📱 Поделиться контактом',
+                                        'request_contact' => true
+                                    ]
+                                ]
+                            ],
+                            'resize_keyboard' => true,
+                            'one_time_keyboard' => true
+                        ];
+
+                        $this->sendMessage(
+                            $chatId,
+                            "⚡ Мгновенная регистрация\n\nНажмите на кнопку «Поделиться контактом» внизу экрана и получите логин и пароль.\n\nРегистрируясь, вы соглашаетесь с <a href='https://wbdiscount.pro/privacy'>политикой конфиденциальности</a> и <a href='https://wbdiscount.pro/terms'>пользовательским соглашением</a>.",
+                            $keyboard,
+                            $forSeller
+                        );
+                    }
 
 
                     if(!str_starts_with($startPayload, 'register') || !str_starts_with($startPayload, 'ref')){
@@ -167,6 +193,10 @@ class TelegramService
                                     ['user_id' => $refUserId, 'type' => 'telegram'],
                                     ['registrations_count' => DB::raw('registrations_count + 1')]
                                 );
+                            }
+
+                            if ($utm = Cache::pull("utm_tg_{$chatId}")) {
+                                $user->update($utm);
                             }
 
                             if($forSeller) {

--- a/database/migrations/2024_12_30_000001_add_utm_fields_to_users_table.php
+++ b/database/migrations/2024_12_30_000001_add_utm_fields_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('utm_source')->nullable();
+            $table->string('utm_medium')->nullable();
+            $table->string('utm_campaign')->nullable();
+            $table->string('utm_content')->nullable();
+            $table->string('utm_term')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'utm_source',
+                'utm_medium',
+                'utm_campaign',
+                'utm_content',
+                'utm_term',
+            ]);
+        });
+    }
+};

--- a/resources/views/admin/buyer/show.blade.php
+++ b/resources/views/admin/buyer/show.blade.php
@@ -43,6 +43,15 @@
 
                     <div class="label mt-3">Email:</div>
                     <div>{{ $user->email }}</div>
+
+                    <div class="label mt-3">UTM (Source):</div>
+                    <div>{{ $user->utm_source ?? '-' }}</div>
+
+                    <div class="label mt-3">UTM (Medium):</div>
+                    <div>{{ $user->utm_medium ?? '-' }}</div>
+
+                    <div class="label mt-3">UTM (Campaign):</div>
+                    <div>{{ $user->utm_campaign ?? '-' }}</div>
                 </div>
 
                 <div class="col-md-6">

--- a/resources/views/admin/seller/show.blade.php
+++ b/resources/views/admin/seller/show.blade.php
@@ -53,6 +53,15 @@
 
                     <div class="label mt-3">Email:</div>
                     <div>{{ $user->email }}</div>
+
+                    <div class="label mt-3">UTM (Source):</div>
+                    <div>{{ $user->utm_source ?? '-' }}</div>
+
+                    <div class="label mt-3">UTM (Medium):</div>
+                    <div>{{ $user->utm_medium ?? '-' }}</div>
+
+                    <div class="label mt-3">UTM (Campaign):</div>
+                    <div>{{ $user->utm_campaign ?? '-' }}</div>
                 </div>
 
                 <div class="col-md-6">

--- a/routes/api.php
+++ b/routes/api.php
@@ -135,6 +135,9 @@ Route::post('/telegram/client/handle', [\App\Http\Controllers\TelegramController
 // Реферальная ссылка
 Route::post('/referral/{id}', [\App\Http\Controllers\ReferralController::class, 'store']);
 
+// Сохранение UTM-меток
+Route::post('/utm', [\App\Http\Controllers\UtmController::class, 'store']);
+
 // Вебхуки CloudPayments
 Route::post('/payment/handle/pay', [\App\Http\Controllers\PaymentController::class, 'handlePay']);
 Route::post('/payment/handle/fail', [\App\Http\Controllers\PaymentController::class, 'handleFail']);


### PR DESCRIPTION
## Summary
- capture UTM parameters via new endpoint and persist them on registration
- save UTM values on user model and expose them in admin seller/buyer pages
- handle UTM start tokens in Telegram bot workflow

## Testing
- `php -l app/Http/Controllers/UtmController.php app/Services/TelegramService.php app/Http/Controllers/TelegramController.php app/Models/User.php`
- `./vendor/bin/phpunit` *(fails: Class "Opcodes\LogViewer\Facades\LogViewer" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c344b42a6483269a43ab661cfdbaae