### PR TITLE
feat: add telegram autoposting for ads

### DIFF
--- a/app/Http/Controllers/Admin/AutopostingController.php
+++ b/app/Http/Controllers/Admin/AutopostingController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\Autoposting\UpdateRequest;
+use App\Models\AutopostLog;
+use App\Models\AutopostSetting;
+
+class AutopostingController extends Controller
+{
+    public function index()
+    {
+        $settings = AutopostSetting::query()->first();
+
+        if (! $settings) {
+            $settings = AutopostSetting::create();
+        }
+
+        $logs = AutopostLog::with('ad')->latest()->paginate(20);
+
+        return view('admin.autoposting.index', compact('settings', 'logs'));
+    }
+
+    public function update(UpdateRequest $request)
+    {
+        $settings = AutopostSetting::query()->first();
+
+        $data = $request->validated();
+
+        if (! $settings) {
+            AutopostSetting::create($data);
+        } else {
+            $settings->update($data);
+        }
+
+        return redirect()->route('admin.autoposting.index')->with('status', 'Настройки обновлены');
+    }
+}

--- a/app/Http/Requests/Admin/Autoposting/UpdateRequest.php
+++ b/app/Http/Requests/Admin/Autoposting/UpdateRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\Admin\Autoposting;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_enabled' => $this->toBoolean('is_enabled'),
+            'show_price' => $this->toBoolean('show_price'),
+            'show_cashback' => $this->toBoolean('show_cashback'),
+            'show_conditions' => $this->toBoolean('show_conditions'),
+            'show_photo' => $this->toBoolean('show_photo'),
+            'show_link' => $this->toBoolean('show_link'),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'is_enabled' => ['required', 'boolean'],
+            'show_price' => ['required', 'boolean'],
+            'show_cashback' => ['required', 'boolean'],
+            'show_conditions' => ['required', 'boolean'],
+            'show_photo' => ['required', 'boolean'],
+            'show_link' => ['required', 'boolean'],
+        ];
+    }
+
+    private function toBoolean(string $key): bool
+    {
+        $value = $this->input($key);
+
+        if ($value === null) {
+            return false;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+    }
+}

--- a/app/Models/AutopostLog.php
+++ b/app/Models/AutopostLog.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AutopostLog extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'is_success' => 'boolean',
+        'response_payload' => 'array',
+    ];
+
+    public function ad(): BelongsTo
+    {
+        return $this->belongsTo(Ad::class);
+    }
+}

--- a/app/Models/AutopostSetting.php
+++ b/app/Models/AutopostSetting.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AutopostSetting extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'is_enabled' => 'boolean',
+        'show_price' => 'boolean',
+        'show_cashback' => 'boolean',
+        'show_conditions' => 'boolean',
+        'show_photo' => 'boolean',
+        'show_link' => 'boolean',
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,12 +30,14 @@ class AppServiceProvider extends ServiceProvider
             return new ConcreteTelegramSessionGuard($provider, $app['request']);
         });
 
-        // Доступ к логам только для админа
-        LogViewer::auth(function ($request) {
-            return $request->user()
-                && in_array($request->user()->email, [
-                    'admin@email.net',
-                ]);
-        });
+        if (class_exists(LogViewer::class)) {
+            // Доступ к логам только для админа
+            LogViewer::auth(function ($request) {
+                return $request->user()
+                    && in_array($request->user()->email, [
+                        'admin@email.net',
+                    ]);
+            });
+        }
     }
 }

--- a/app/Services/AutopostingService.php
+++ b/app/Services/AutopostingService.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Ad;
+use App\Models\AutopostLog;
+use App\Models\AutopostSetting;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class AutopostingService
+{
+    public function publishAd(Ad $ad): void
+    {
+        $settings = AutopostSetting::query()->first();
+
+        if (! $settings || ! $settings->is_enabled || ! $ad->status) {
+            return;
+        }
+
+        $ad->loadMissing('product');
+
+        $chatId = config('services.telegram.autopost_chat_id', '-3026543670');
+        $botToken = config('services.telegram.autopost_token') ?: config('services.telegram.token');
+
+        if (! $botToken) {
+            AutopostLog::create([
+                'ad_id' => $ad->id,
+                'chat_id' => $chatId,
+                'is_success' => false,
+                'message' => null,
+                'error_message' => 'Telegram bot token is not configured.',
+            ]);
+
+            return;
+        }
+
+        $message = $this->buildMessage($ad, $settings);
+        $keyboard = $this->buildKeyboard($ad, $settings);
+        $photoUrl = $settings->show_photo ? $this->getPhotoUrl($ad) : null;
+
+        $payload = [
+            'chat_id' => $chatId,
+            'parse_mode' => 'HTML',
+        ];
+
+        if (! empty($keyboard)) {
+            $payload['reply_markup'] = json_encode($keyboard, JSON_UNESCAPED_UNICODE);
+        }
+
+        try {
+            if ($photoUrl) {
+                $payload['photo'] = $photoUrl;
+                $payload['caption'] = $message;
+                $response = Http::asForm()->timeout(10)->post("https://api.telegram.org/bot{$botToken}/sendPhoto", $payload);
+            } else {
+                $payload['text'] = $message;
+                $response = Http::asForm()->timeout(10)->post("https://api.telegram.org/bot{$botToken}/sendMessage", $payload);
+            }
+
+            $responseData = $response->json();
+            $isOk = $response->successful() && Arr::get($responseData, 'ok') === true;
+
+            AutopostLog::create([
+                'ad_id' => $ad->id,
+                'chat_id' => $chatId,
+                'is_success' => $isOk,
+                'message' => $message,
+                'error_message' => $isOk ? null : ($responseData['description'] ?? $response->body()),
+                'response_payload' => $responseData,
+            ]);
+
+            if (! $isOk) {
+                Log::error('Autoposting failed', [
+                    'ad_id' => $ad->id,
+                    'response' => $responseData,
+                ]);
+            }
+        } catch (\Throwable $exception) {
+            AutopostLog::create([
+                'ad_id' => $ad->id,
+                'chat_id' => $chatId,
+                'is_success' => false,
+                'message' => $message,
+                'error_message' => $exception->getMessage(),
+            ]);
+
+            Log::error('Autoposting exception', [
+                'ad_id' => $ad->id,
+                'message' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    protected function buildMessage(Ad $ad, AutopostSetting $settings): string
+    {
+        $lines = [];
+        $lines[] = '<b>'.e($ad->name).'</b>';
+
+        if ($settings->show_price) {
+            $lines[] = 'Цена: '.number_format((float) $ad->price_with_cashback, 2, '.', ' ').' ₽';
+        }
+
+        if ($settings->show_cashback) {
+            $lines[] = 'Кэшбек: '.$this->formatPercentage($ad->cashback_percentage);
+        }
+
+        if ($settings->show_conditions) {
+            $conditions = $this->prepareConditions($ad->order_conditions);
+            if ($conditions !== '') {
+                $lines[] = '';
+                $lines[] = $conditions;
+            }
+        }
+
+        if (! $settings->show_link) {
+            $lines[] = '';
+            $lines[] = 'Перейти к товару: '.$this->buildProductUrl($ad);
+        }
+
+        return trim(implode("\n", array_filter($lines, static fn ($line) => $line !== null)));
+    }
+
+    protected function buildKeyboard(Ad $ad, AutopostSetting $settings): array
+    {
+        if (! $settings->show_link) {
+            return [];
+        }
+
+        return [
+            'inline_keyboard' => [
+                [
+                    [
+                        'text' => 'Перейти к товару',
+                        'url' => $this->buildProductUrl($ad),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    protected function buildProductUrl(Ad $ad): string
+    {
+        $base = rtrim(config('app.frontend_url') ?? config('app.url'), '/');
+        $productId = $ad->product?->id ?? $ad->product_id;
+
+        return $base.'/product/'.$productId;
+    }
+
+    protected function getPhotoUrl(Ad $ad): ?string
+    {
+        $images = $ad->product?->images ?? [];
+
+        if (is_array($images) && count($images) > 0) {
+            return $images[0];
+        }
+
+        return null;
+    }
+
+    protected function prepareConditions(?string $conditions): string
+    {
+        if (! $conditions) {
+            return '';
+        }
+
+        $text = str_ireplace(['<br />', '<br/>', '<br>'], "\n", $conditions);
+        $text = strip_tags($text);
+        $text = html_entity_decode($text);
+
+        return e(trim($text));
+    }
+
+    protected function formatPercentage($value): string
+    {
+        $formatted = number_format((float) $value, 2, '.', ' ');
+        $formatted = Str::of($formatted)->rtrim('0')->rtrim('.');
+
+        return $formatted.'%';
+    }
+}

--- a/app/Services/Seller/AdsService.php
+++ b/app/Services/Seller/AdsService.php
@@ -7,6 +7,7 @@ use App\Models\FrozenBalance;
 use App\Models\Product;
 use App\Models\Tariff;
 use App\Models\Transaction;
+use App\Services\AutopostingService;
 use App\Services\BaseService;
 use Illuminate\Support\Facades\DB;
 
@@ -92,6 +93,10 @@ class AdsService extends BaseService
 //            ]);
 
             DB::commit();
+
+            if ($ad->status) {
+                app(AutopostingService::class)->publishAd($ad->loadMissing('product'));
+            }
 
             return Response()->json([
                 'ads'  => $ad->load('product', 'shop')

--- a/config/services.php
+++ b/config/services.php
@@ -47,6 +47,8 @@ return [
         'username' => env('TELEGRAM_BOT_USERNAME'),
         'client_token' => env('TELEGRAM_CLIENT_TOKEN'),
         'client_username' => env('TELEGRAM_CLIENT_USERNAME'),
+        'autopost_token' => env('TELEGRAM_AUTOPOST_BOT_TOKEN'),
+        'autopost_chat_id' => env('TELEGRAM_AUTOPOST_CHAT_ID', '-3026543670'),
     ],
 
     'cloudpayments' => [

--- a/database/migrations/2025_07_10_120000_create_autopost_settings_table.php
+++ b/database/migrations/2025_07_10_120000_create_autopost_settings_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('autopost_settings', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('is_enabled')->default(false);
+            $table->boolean('show_price')->default(true);
+            $table->boolean('show_cashback')->default(true);
+            $table->boolean('show_conditions')->default(false);
+            $table->boolean('show_photo')->default(true);
+            $table->boolean('show_link')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('autopost_settings');
+    }
+};

--- a/database/migrations/2025_07_10_120100_create_autopost_logs_table.php
+++ b/database/migrations/2025_07_10_120100_create_autopost_logs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('autopost_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ad_id')->nullable()->constrained('ads')->nullOnDelete();
+            $table->string('chat_id')->index();
+            $table->boolean('is_success')->default(false);
+            $table->text('message')->nullable();
+            $table->text('error_message')->nullable();
+            $table->json('response_payload')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('autopost_logs');
+    }
+};

--- a/resources/views/admin/autoposting/index.blade.php
+++ b/resources/views/admin/autoposting/index.blade.php
@@ -1,0 +1,135 @@
+@extends('layouts.main')
+
+@section('title', 'Автопостинг')
+
+@section('content')
+    <div class="row">
+        <div class="col-xl-5 col-lg-6">
+            <div class="card mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">Настройки автопостинга</h5>
+                </div>
+                <div class="card-body">
+                    @if (session('status'))
+                        <div class="alert alert-success alert-dismissible" role="alert">
+                            {{ session('status') }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                        </div>
+                    @endif
+
+                    <form method="POST" action="{{ route('admin.autoposting.update') }}">
+                        @csrf
+                        @method('PUT')
+
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="is_enabled" name="is_enabled" value="1" {{ old('is_enabled', $settings->is_enabled) ? 'checked' : '' }}>
+                            <label class="form-check-label" for="is_enabled">Включить автопостинг</label>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label d-block">Что публиковать</label>
+
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="show_photo" name="show_photo" value="1" {{ old('show_photo', $settings->show_photo) ? 'checked' : '' }}>
+                                <label class="form-check-label" for="show_photo">Фото товара</label>
+                            </div>
+
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="show_price" name="show_price" value="1" {{ old('show_price', $settings->show_price) ? 'checked' : '' }}>
+                                <label class="form-check-label" for="show_price">Цена</label>
+                            </div>
+
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="show_cashback" name="show_cashback" value="1" {{ old('show_cashback', $settings->show_cashback) ? 'checked' : '' }}>
+                                <label class="form-check-label" for="show_cashback">Кэшбек</label>
+                            </div>
+
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="show_conditions" name="show_conditions" value="1" {{ old('show_conditions', $settings->show_conditions) ? 'checked' : '' }}>
+                                <label class="form-check-label" for="show_conditions">Условия</label>
+                            </div>
+
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="show_link" name="show_link" value="1" {{ old('show_link', $settings->show_link) ? 'checked' : '' }}>
+                                <label class="form-check-label" for="show_link">Кнопка «Перейти к товару»</label>
+                            </div>
+                        </div>
+
+                        @if ($errors->any())
+                            <div class="alert alert-danger">
+                                <ul class="mb-0">
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        <button type="submit" class="btn btn-primary">Сохранить</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-xl-7 col-lg-6">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">Логи публикаций</h5>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0">
+                            <thead>
+                            <tr>
+                                <th class="text-nowrap">Дата</th>
+                                <th>Объявление</th>
+                                <th>Статус</th>
+                                <th>Сообщение</th>
+                                <th>Ошибка</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @php use Illuminate\Support\Str; @endphp
+                            @forelse($logs as $log)
+                                <tr>
+                                    <td class="text-nowrap">{{ $log->created_at?->format('d.m.Y H:i') }}</td>
+                                    <td>
+                                        @if($log->ad)
+                                            {{ $log->ad->name }}
+                                        @else
+                                            <span class="text-muted">Объявление #{{ $log->ad_id }} удалено</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($log->is_success)
+                                            <span class="badge bg-success">Успех</span>
+                                        @else
+                                            <span class="badge bg-danger">Ошибка</span>
+                                        @endif
+                                    </td>
+                                    <td>{{ Str::limit(strip_tags($log->message ?? ''), 80) }}</td>
+                                    <td>
+                                        @if($log->error_message)
+                                            <span class="text-danger">{{ Str::limit($log->error_message, 80) }}</span>
+                                        @else
+                                            <span class="text-muted">—</span>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="text-center py-4">Логи отсутствуют</td>
+                                </tr>
+                            @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="p-3">
+                        {{ $logs->links('inc.pagination') }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -174,6 +174,13 @@
                 </li>
 
                 <li class="menu-item">
+                    <a href="{{route('admin.autoposting.index')}}" class="menu-link">
+                        <i class="menu-icon tf-icons bx bx-send"></i>
+                        <div class="text-truncate" data-i18n="Basic">Автопостинг</div>
+                    </a>
+                </li>
+
+                <li class="menu-item">
                     <a href="{{route('admin.settings.index')}}" class="menu-link">
                         <i class="menu-icon tf-icons bx bx-cog"></i>
                         <div class="text-truncate" data-i18n="Basic">Настройки</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,4 +50,6 @@ Route::middleware(['auth', 'is.admin'])->name('admin.')->group(function () {
     Route::resource('buybacks', App\Http\Controllers\Admin\BuybacksController::class)->only(['index', 'show']);
     Route::get('settings', [App\Http\Controllers\Admin\SettingsController::class, 'index'])->name('settings.index');
     Route::put('settings', [App\Http\Controllers\Admin\SettingsController::class, 'update'])->name('settings.update');
+    Route::get('/autoposting', [\App\Http\Controllers\Admin\AutopostingController::class, 'index'])->name('autoposting.index');
+    Route::put('/autoposting', [\App\Http\Controllers\Admin\AutopostingController::class, 'update'])->name('autoposting.update');
 });

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,6 +14,7 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertStatus(302);
+        $response->assertRedirect(route('login'));
     }
 }


### PR DESCRIPTION
## Summary
- add telegram autoposting service for active ads with configurable message content and logging
- expose autoposting settings and log viewer in the admin panel with dedicated migrations and request handling
- wire up configuration, navigation, and tests to cover the authenticated redirect while hardening optional log viewer usage

## Testing
- APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cca14f50d483268418946a6c308517