### PR TITLE
feat: allow admin impersonation via secure token exchange

### DIFF
--- a/app/Http/Controllers/ImpersonationController.php
+++ b/app/Http/Controllers/ImpersonationController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Impersonation\ExchangeRequest;
+use App\Models\ImpersonationToken;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+
+class ImpersonationController extends Controller
+{
+    public function exchange(ExchangeRequest $request): JsonResponse
+    {
+        $plainToken = $request->validated('token');
+        $tokenHash = hash('sha256', $plainToken);
+
+        $impersonation = ImpersonationToken::query()
+            ->where('token_hash', $tokenHash)
+            ->whereNull('used_at')
+            ->first();
+
+        if (! $impersonation || $impersonation->expires_at->isPast()) {
+            return response()->json([
+                'message' => 'Ссылка недействительна или устарела',
+            ], 422);
+        }
+
+        $user = User::query()->find($impersonation->user_id);
+
+        if (! $user) {
+            $impersonation->delete();
+
+            return response()->json([
+                'message' => 'Пользователь не найден',
+            ], 404);
+        }
+
+        $token = $user->createToken(
+            name: 'impersonation-admin-'.$impersonation->admin_id,
+            abilities: ['impersonation'],
+            expiresAt: now()->addHours(2)
+        );
+
+        $impersonation->forceFill([
+            'used_at' => now(),
+            'used_ip' => $request->ip(),
+            'used_user_agent' => $request->userAgent(),
+        ])->save();
+
+        Log::info('Admin impersonation exchange completed', [
+            'admin_id' => $impersonation->admin_id,
+            'user_id' => $user->id,
+            'impersonation_id' => $impersonation->id,
+        ]);
+
+        return response()->json([
+            'token' => $token->plainTextToken,
+            'user' => $user,
+        ]);
+    }
+}

--- a/app/Http/Requests/Impersonation/ExchangeRequest.php
+++ b/app/Http/Requests/Impersonation/ExchangeRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Impersonation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ExchangeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'token' => ['required', 'string', 'min:40', 'max:120'],
+        ];
+    }
+}

--- a/app/Models/ImpersonationToken.php
+++ b/app/Models/ImpersonationToken.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ImpersonationToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'admin_id',
+        'user_id',
+        'token_hash',
+        'expires_at',
+        'used_at',
+        'used_ip',
+        'used_user_agent',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'used_at' => 'datetime',
+    ];
+
+    public function admin(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'admin_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/migrations/2025_09_19_120101_create_impersonation_tokens_table.php
+++ b/database/migrations/2025_09_19_120101_create_impersonation_tokens_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('impersonation_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('admin_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('token_hash', 64)->unique();
+            $table->timestamp('expires_at');
+            $table->timestamp('used_at')->nullable();
+            $table->string('used_ip')->nullable();
+            $table->string('used_user_agent')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('impersonation_tokens');
+    }
+};

--- a/resources/views/admin/buyer/show.blade.php
+++ b/resources/views/admin/buyer/show.blade.php
@@ -83,7 +83,7 @@
 
             <!-- Кнопки снизу слева -->
             <div class="mt-4 d-flex gap-2">
-                <a href="{{ route('admin.loginAs', $user->id) }}" class="btn btn-warning">
+                <a href="{{ route('admin.loginAs', $user->id) }}" class="btn btn-warning" target="_blank" rel="noopener">
                     Авторизоваться под пользователем
                 </a>
                 <form action="{{ route('admin.buyer.destroy', $user->id) }}" method="POST" onsubmit="return confirm('Удалить пользователя?')">

--- a/resources/views/admin/seller/show.blade.php
+++ b/resources/views/admin/seller/show.blade.php
@@ -96,7 +96,7 @@
 
             <!-- Кнопки снизу слева -->
             <div class="mt-4 d-flex gap-2">
-                <a href="{{ route('admin.loginAs', $user->id) }}" class="btn btn-warning">
+                <a href="{{ route('admin.loginAs', $user->id) }}" class="btn btn-warning" target="_blank" rel="noopener">
                     Авторизоваться под пользователем
                 </a>
                 <form action="{{ route('admin.sellers.destroy', $user->id) }}" method="POST" onsubmit="return confirm('Удалить пользователя?')">

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ImpersonationController;
 use App\Http\Middleware\GuestOnly;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
@@ -43,6 +44,7 @@ Route::middleware([GuestOnly::class])->group(function () {
 
     Route::post('login', [\App\Http\Controllers\AuthController::class, 'login']);
     Route::post('register/password', [\App\Http\Controllers\AuthController::class, 'register']);
+    Route::post('impersonation/exchange', [ImpersonationController::class, 'exchange'])->name('impersonation.exchange');
 });
 Route::get('/roles', [\App\Http\Controllers\AuthController::class, 'roles']);
 

--- a/tests/Feature/Admin/LoginAsUserTest.php
+++ b/tests/Feature/Admin/LoginAsUserTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\ImpersonationToken;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class LoginAsUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::unguarded(function () {
+            Role::query()->create(['id' => 1, 'name' => 'Admin', 'slug' => 'admin']);
+            Role::query()->create(['id' => 2, 'name' => 'Seller', 'slug' => 'seller']);
+        });
+
+        config(['app.frontend_url' => 'https://front.example']);
+    }
+
+    public function test_admin_can_impersonate_user(): void
+    {
+        $admin = User::factory()->create(['role_id' => 1]);
+        $seller = User::factory()->create(['role_id' => 2]);
+
+        $response = $this->actingAs($admin)->get(route('admin.loginAs', $seller->id));
+
+        $response->assertRedirect();
+
+        $redirectUrl = $response->headers->get('Location');
+        $this->assertNotNull($redirectUrl);
+        $this->assertStringContainsString('https://front.example', $redirectUrl);
+
+        $parts = parse_url($redirectUrl);
+        parse_str($parts['query'] ?? '', $query);
+
+        $this->assertArrayHasKey('impersonation_token', $query);
+        $plainToken = $query['impersonation_token'];
+        $tokenHash = hash('sha256', $plainToken);
+
+        $this->assertDatabaseHas('impersonation_tokens', [
+            'admin_id' => $admin->id,
+            'user_id' => $seller->id,
+            'token_hash' => $tokenHash,
+        ]);
+
+        $now = Carbon::parse('2025-01-01 12:00:00');
+        Carbon::setTestNow($now);
+
+        $exchange = $this->postJson(route('impersonation.exchange'), [
+            'token' => $plainToken,
+        ]);
+
+        $exchange->assertOk();
+        $exchange->assertJsonStructure([
+            'token',
+            'user' => ['id', 'name'],
+        ]);
+
+        $this->assertDatabaseHas('impersonation_tokens', [
+            'token_hash' => $tokenHash,
+            'used_at' => $now,
+        ]);
+
+        $this->assertNotNull(ImpersonationToken::query()->where('token_hash', $tokenHash)->value('used_ip'));
+
+        $secondAttempt = $this->postJson(route('impersonation.exchange'), [
+            'token' => $plainToken,
+        ]);
+
+        $secondAttempt->assertStatus(422);
+
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
## Summary
- add secure token generation flow for admin impersonation links and log creation
- expose API endpoint to exchange one-time impersonation tokens for sanctum tokens with audit trail
- ensure admin UI opens impersonation in new tab and cover flow with feature test plus supporting migration/model

## Testing
- Unable to run `php artisan test` (missing vendor directory and composer install blocked by network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68ccb356e0c0832689403f3baf7c261f