### PR TITLE
Add seller freeze controls in admin panel

### DIFF
--- a/resources/views/admin/seller/show.blade.php
+++ b/resources/views/admin/seller/show.blade.php
@@ -104,7 +104,27 @@
                     @method('DELETE')
                     <button type="submit" class="btn btn-danger">Удалить пользователя</button>
                 </form>
+                @if($user->is_frozen)
+                    <button class="btn btn-success" onclick="unfrozen()">Разморозить пользователя</button>
+                @else
+                    <button class="btn btn-dark" onclick="frozen()">Заморозить пользователя</button>
+                @endif
             </div>
         </div>
     </div>
+@endsection
+
+@section('scripts')
+    <script>
+        function unfrozen() {
+            if (confirm('Разморозить пользователя?')) {
+                location.href = '{{ route('admin.user.unfrozen', $user->id) }}'
+            }
+        }
+        function frozen() {
+            if (confirm('Заморозить пользователя?')) {
+                location.href = '{{ route('admin.user.frozen', $user->id) }}'
+            }
+        }
+    </script>
 @endsection


### PR DESCRIPTION
## Summary
- add freeze/unfreeze action buttons to the admin seller details page
- include client-side handlers that reuse existing admin routes for freezing and unfreezing users

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing before dependencies installed)*
- `composer install` *(fails: requires GitHub token when downloading carbonphp/carbon-doctrine-types)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8e27eec483268fc8a7686c6c4a1f