### PR TITLE
Add Telegram users management section in admin panel

### DIFF
--- a/app/Http/Controllers/Admin/TelegramUserController.php
+++ b/app/Http/Controllers/Admin/TelegramUserController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class TelegramUserController extends Controller
+{
+    private const PYTHON_COMMAND = 'python3';
+    private const SCRIPT_PATH = '/home/b/blocksre/wbd-back.ru/public_html/public/index.py';
+    private const ALL_MEMBERS_FILE = '/home/b/blocksre/wbd-back.ru/public_html/public/all_members.csv';
+    private const NEW_MEMBERS_FILE = '/home/b/blocksre/wbd-back.ru/public_html/public/new_members.csv';
+
+    public function index(): View
+    {
+        return view('admin.telegram-users.index');
+    }
+
+    public function refresh(): RedirectResponse
+    {
+        $process = new Process([self::PYTHON_COMMAND, self::SCRIPT_PATH]);
+
+        try {
+            $process->setTimeout(300);
+            $process->run();
+
+            if (! $process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+        } catch (\Throwable $exception) {
+            Log::error('Не удалось обновить список пользователей TG', [
+                'exception' => $exception,
+            ]);
+
+            return redirect()
+                ->route('admin.telegram-users.index')
+                ->with('error', 'Не удалось обновить пользователей TG. Проверьте логи для подробностей.');
+        }
+
+        return redirect()
+            ->route('admin.telegram-users.index')
+            ->with('success', 'Список пользователей TG успешно обновлён.');
+    }
+
+    public function downloadAll(): RedirectResponse|BinaryFileResponse
+    {
+        return $this->downloadFile(self::ALL_MEMBERS_FILE, 'all_members.csv');
+    }
+
+    public function downloadNew(): RedirectResponse|BinaryFileResponse
+    {
+        return $this->downloadFile(self::NEW_MEMBERS_FILE, 'new_members.csv');
+    }
+
+    private function downloadFile(string $filePath, string $downloadName): RedirectResponse|BinaryFileResponse
+    {
+        if (! file_exists($filePath)) {
+            return redirect()
+                ->route('admin.telegram-users.index')
+                ->with('error', 'Файл не найден: ' . $downloadName);
+        }
+
+        return response()->download($filePath, $downloadName);
+    }
+}
+

--- a/resources/views/admin/telegram-users/index.blade.php
+++ b/resources/views/admin/telegram-users/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.main')
+
+@section('title', 'Пользователи TG')
+
+@section('content')
+    <div class="row">
+        <div class="col-12">
+            @if(session('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+            @endif
+
+            @if(session('error'))
+                <div class="alert alert-danger">{{ session('error') }}</div>
+            @endif
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">Пользователи Telegram</h5>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-wrap gap-2">
+                        <form action="{{ route('admin.telegram-users.refresh') }}" method="POST">
+                            @csrf
+                            <button type="submit" class="btn btn-primary">Обновить</button>
+                        </form>
+                        <a class="btn btn-outline-secondary" href="{{ route('admin.telegram-users.all') }}">Все участники</a>
+                        <a class="btn btn-outline-secondary" href="{{ route('admin.telegram-users.new') }}">Новые участники</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -181,6 +181,13 @@
                 </li>
 
                 <li class="menu-item">
+                    <a href="{{route('admin.telegram-users.index')}}" class="menu-link">
+                        <i class="menu-icon tf-icons bx bx-message-square-detail"></i>
+                        <div class="text-truncate" data-i18n="Basic">Пользователи TG</div>
+                    </a>
+                </li>
+
+                <li class="menu-item">
                     <a href="{{route('admin.settings.index')}}" class="menu-link">
                         <i class="menu-icon tf-icons bx bx-cog"></i>
                         <div class="text-truncate" data-i18n="Basic">Настройки</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\TelegramUserController;
 
 Route::get('/login', function () {
     return view('admin.login');
@@ -52,4 +53,11 @@ Route::middleware(['auth', 'is.admin'])->name('admin.')->group(function () {
     Route::put('settings', [App\Http\Controllers\Admin\SettingsController::class, 'update'])->name('settings.update');
     Route::get('/autoposting', [\App\Http\Controllers\Admin\AutopostingController::class, 'index'])->name('autoposting.index');
     Route::put('/autoposting', [\App\Http\Controllers\Admin\AutopostingController::class, 'update'])->name('autoposting.update');
+
+    Route::prefix('telegram-users')->name('telegram-users.')->group(function () {
+        Route::get('/', [TelegramUserController::class, 'index'])->name('index');
+        Route::post('/refresh', [TelegramUserController::class, 'refresh'])->name('refresh');
+        Route::get('/all', [TelegramUserController::class, 'downloadAll'])->name('all');
+        Route::get('/new', [TelegramUserController::class, 'downloadNew'])->name('new');
+    });
 });


### PR DESCRIPTION
## Summary
- add an admin controller and routes to refresh TG users via the required Python script and download CSV exports
- create an admin view and navigation entry for the Telegram users section with action buttons

## Testing
- php artisan test *(fails: vendor/autoload.php missing prior to installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d8245ad64883269070e7d8c96eb2f0