### PR TITLE
Improve Telegram refresh error diagnostics

### DIFF
--- a/app/Http/Controllers/Admin/TelegramUserController.php
+++ b/app/Http/Controllers/Admin/TelegramUserController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\Process\Process;
+
+class TelegramUserController extends Controller
+{
+    private const PYTHON_COMMAND = 'python3';
+    private const SCRIPT_PATH = '/home/b/blocksre/wbd-back.ru/public_html/public/index.py';
+    private const ALL_MEMBERS_FILE = '/home/b/blocksre/wbd-back.ru/public_html/public/all_members.csv';
+    private const NEW_MEMBERS_FILE = '/home/b/blocksre/wbd-back.ru/public_html/public/new_members.csv';
+
+    public function index(): View
+    {
+        return view('admin.telegram-users.index');
+    }
+
+    public function refresh(): RedirectResponse
+    {
+        $process = new Process([
+            self::PYTHON_COMMAND,
+            basename(self::SCRIPT_PATH),
+        ]);
+
+        $process->setTimeout(300);
+        $process->setWorkingDirectory(dirname(self::SCRIPT_PATH));
+
+        try {
+            $process->run();
+        } catch (\Throwable $exception) {
+            Log::error('Не удалось запустить процесс обновления пользователей TG', [
+                'exception' => $exception,
+            ]);
+
+            return redirect()
+                ->route('admin.telegram-users.index')
+                ->with('error', 'Не удалось запустить обновление пользователей TG. Проверьте логи для подробностей.');
+        }
+
+        if ($process->isSuccessful()) {
+            return redirect()
+                ->route('admin.telegram-users.index')
+                ->with('success', 'Список пользователей TG успешно обновлён.');
+        }
+
+        $errorMessage = $this->resolveProcessErrorMessage($process);
+
+        Log::error('Процесс обновления пользователей TG завершился с ошибкой', [
+            'exit_code' => $process->getExitCode(),
+            'output' => $process->getOutput(),
+            'error_output' => $process->getErrorOutput(),
+        ]);
+
+        return redirect()
+            ->route('admin.telegram-users.index')
+            ->with('error', $errorMessage);
+    }
+
+    public function downloadAll(): RedirectResponse|BinaryFileResponse
+    {
+        return $this->downloadFile(self::ALL_MEMBERS_FILE, 'all_members.csv');
+    }
+
+    public function downloadNew(): RedirectResponse|BinaryFileResponse
+    {
+        return $this->downloadFile(self::NEW_MEMBERS_FILE, 'new_members.csv');
+    }
+
+    private function downloadFile(string $filePath, string $downloadName): RedirectResponse|BinaryFileResponse
+    {
+        if (! file_exists($filePath)) {
+            return redirect()
+                ->route('admin.telegram-users.index')
+                ->with('error', 'Файл не найден: ' . $downloadName);
+        }
+
+        return response()->download($filePath, $downloadName);
+    }
+
+    private function resolveProcessErrorMessage(Process $process): string
+    {
+        $errorOutput = $process->getErrorOutput();
+
+        if (preg_match("/ModuleNotFoundError: No module named '([^']+)'/", $errorOutput, $matches)) {
+            $missingModule = $matches[1];
+
+            return sprintf(
+                'Python не нашёл модуль "%s". Установите его для пользователя веб-сервера: pip3 install --user %s',
+                $missingModule,
+                $missingModule
+            );
+        }
+
+        if ($errorOutput !== '') {
+            return 'Команда завершилась с ошибкой: ' . trim($errorOutput);
+        }
+
+        if ($process->getExitCode() !== null) {
+            return 'Команда завершилась с кодом ' . $process->getExitCode() . '. Проверьте логи для подробностей.';
+        }
+
+        return 'Не удалось обновить пользователей TG. Проверьте логи для подробностей.';
+    }
+}
+

--- a/resources/views/admin/telegram-users/index.blade.php
+++ b/resources/views/admin/telegram-users/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.main')
+
+@section('title', 'Пользователи TG')
+
+@section('content')
+    <div class="row">
+        <div class="col-12">
+            @if(session('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+            @endif
+
+            @if(session('error'))
+                <div class="alert alert-danger">{{ session('error') }}</div>
+            @endif
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">Пользователи Telegram</h5>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-wrap gap-2">
+                        <form action="{{ route('admin.telegram-users.refresh') }}" method="POST">
+                            @csrf
+                            <button type="submit" class="btn btn-primary">Обновить</button>
+                        </form>
+                        <a class="btn btn-outline-secondary" href="{{ route('admin.telegram-users.all') }}">Все участники</a>
+                        <a class="btn btn-outline-secondary" href="{{ route('admin.telegram-users.new') }}">Новые участники</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -181,6 +181,13 @@
                 </li>
 
                 <li class="menu-item">
+                    <a href="{{route('admin.telegram-users.index')}}" class="menu-link">
+                        <i class="menu-icon tf-icons bx bx-message-square-detail"></i>
+                        <div class="text-truncate" data-i18n="Basic">Пользователи TG</div>
+                    </a>
+                </li>
+
+                <li class="menu-item">
                     <a href="{{route('admin.settings.index')}}" class="menu-link">
                         <i class="menu-icon tf-icons bx bx-cog"></i>
                         <div class="text-truncate" data-i18n="Basic">Настройки</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\TelegramUserController;
 
 Route::get('/login', function () {
     return view('admin.login');
@@ -52,4 +53,11 @@ Route::middleware(['auth', 'is.admin'])->name('admin.')->group(function () {
     Route::put('settings', [App\Http\Controllers\Admin\SettingsController::class, 'update'])->name('settings.update');
     Route::get('/autoposting', [\App\Http\Controllers\Admin\AutopostingController::class, 'index'])->name('autoposting.index');
     Route::put('/autoposting', [\App\Http\Controllers\Admin\AutopostingController::class, 'update'])->name('autoposting.update');
+
+    Route::prefix('telegram-users')->name('telegram-users.')->group(function () {
+        Route::get('/', [TelegramUserController::class, 'index'])->name('index');
+        Route::post('/refresh', [TelegramUserController::class, 'refresh'])->name('refresh');
+        Route::get('/all', [TelegramUserController::class, 'downloadAll'])->name('all');
+        Route::get('/new', [TelegramUserController::class, 'downloadNew'])->name('new');
+    });
 });


### PR DESCRIPTION
## Summary
- run the Telegram refresh script from its directory and keep the process output for debugging
- provide a clearer error message when Python dependencies such as telethon are missing
- surface the command output and exit code through logs while keeping the admin UI responsive

## Testing
- php -l app/Http/Controllers/Admin/TelegramUserController.php

------
https://chatgpt.com/codex/tasks/task_e_68d8245ad64883269070e7d8c96eb2f0