### PR TITLE
Add admin endpoint to install Telegram dependencies

### DIFF
--- a/app/Http/Controllers/Admin/TelegramUserController.php
+++ b/app/Http/Controllers/Admin/TelegramUserController.php
@@ -48,6 +48,40 @@ class TelegramUserController extends Controller
             ->with('success', 'Список пользователей TG успешно обновлён.');
     }
 
+    public function installDependencies(): RedirectResponse
+    {
+        $process = new Process([
+            self::PYTHON_COMMAND,
+            '-m',
+            'pip',
+            'install',
+            '--no-cache-dir',
+            'telethon',
+            'pandas',
+        ]);
+
+        try {
+            $process->setTimeout(300);
+            $process->run();
+
+            if (! $process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+        } catch (\Throwable $exception) {
+            Log::error('Не удалось установить зависимости для TG', [
+                'exception' => $exception,
+            ]);
+
+            return redirect()
+                ->route('admin.telegram-users.index')
+                ->with('error', 'Не удалось установить зависимости. Проверьте логи для подробностей.');
+        }
+
+        return redirect()
+            ->route('admin.telegram-users.index')
+            ->with('success', 'Зависимости для TG успешно установлены.');
+    }
+
     public function downloadAll(): RedirectResponse|BinaryFileResponse
     {
         return $this->downloadFile(self::ALL_MEMBERS_FILE, 'all_members.csv');

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,7 @@ Route::middleware(['auth', 'is.admin'])->name('admin.')->group(function () {
     Route::prefix('telegram-users')->name('telegram-users.')->group(function () {
         Route::get('/', [TelegramUserController::class, 'index'])->name('index');
         Route::post('/refresh', [TelegramUserController::class, 'refresh'])->name('refresh');
+        Route::post('/install', [TelegramUserController::class, 'installDependencies'])->name('install');
         Route::get('/all', [TelegramUserController::class, 'downloadAll'])->name('all');
         Route::get('/new', [TelegramUserController::class, 'downloadNew'])->name('new');
     });


### PR DESCRIPTION
## Summary
- add a controller action that installs the required Python packages for Telegram sync
- expose a new admin route to trigger the installation from the panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8282fe5d0832688942e4aa96af508