### PR TITLE
Handle python dependency installation without root access

### DIFF
--- a/app/Http/Controllers/Admin/TelegramUserController.php
+++ b/app/Http/Controllers/Admin/TelegramUserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -24,10 +25,12 @@ class TelegramUserController extends Controller
 
     public function refresh(): RedirectResponse
     {
-        $process = new Process([self::PYTHON_COMMAND, self::SCRIPT_PATH]);
+        $process = $this->createPythonProcess(
+            [self::PYTHON_COMMAND, self::SCRIPT_PATH],
+            dirname(self::SCRIPT_PATH)
+        );
 
         try {
-            $process->setTimeout(300);
             $process->run();
 
             if (! $process->isSuccessful()) {
@@ -46,6 +49,87 @@ class TelegramUserController extends Controller
         return redirect()
             ->route('admin.telegram-users.index')
             ->with('success', 'Список пользователей TG успешно обновлён.');
+    }
+
+    public function installDependencies(): RedirectResponse
+    {
+        $targetDirectory = $this->getPythonDependenciesPath();
+
+        $this->ensureDirectoryExists($targetDirectory);
+
+        $process = $this->createPythonProcess([
+            self::PYTHON_COMMAND,
+            '-m',
+            'pip',
+            'install',
+            '--no-cache-dir',
+            '--target',
+            $targetDirectory,
+            'telethon',
+            'pandas',
+        ], dirname(self::SCRIPT_PATH));
+
+        try {
+            $process->run();
+
+            if (! $process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+        } catch (\Throwable $exception) {
+            Log::error('Не удалось установить зависимости для TG', [
+                'exception' => $exception,
+            ]);
+
+            return redirect()
+                ->route('admin.telegram-users.index')
+                ->with('error', 'Не удалось установить зависимости. Проверьте логи для подробностей.');
+        }
+
+        return redirect()
+            ->route('admin.telegram-users.index')
+            ->with('success', 'Зависимости для TG успешно установлены.');
+    }
+
+    private function createPythonProcess(array $command, ?string $workingDirectory = null): Process
+    {
+        $process = new Process($command, $workingDirectory);
+        $process->setTimeout(300);
+
+        $env = $this->buildPythonEnvironment($process->getEnv());
+        $process->setEnv($env);
+
+        return $process;
+    }
+
+    private function buildPythonEnvironment(array $baseEnv): array
+    {
+        $targetDirectory = $this->getPythonDependenciesPath();
+
+        $pythonPath = $targetDirectory;
+
+        if (! empty($baseEnv['PYTHONPATH'])) {
+            $pythonPath .= PATH_SEPARATOR . $baseEnv['PYTHONPATH'];
+        } elseif (($current = getenv('PYTHONPATH')) !== false && $current !== '') {
+            $pythonPath .= PATH_SEPARATOR . $current;
+        }
+
+        return array_merge($baseEnv, [
+            'PYTHONPATH' => $pythonPath,
+        ]);
+    }
+
+    private function getPythonDependenciesPath(): string
+    {
+        return storage_path('app/python-dependencies');
+    }
+
+    private function ensureDirectoryExists(string $directory): void
+    {
+        if (is_dir($directory)) {
+            return;
+        }
+
+        File::makeDirectory($directory, 0755, true, true);
     }
 
     public function downloadAll(): RedirectResponse|BinaryFileResponse

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,7 @@ Route::middleware(['auth', 'is.admin'])->name('admin.')->group(function () {
     Route::prefix('telegram-users')->name('telegram-users.')->group(function () {
         Route::get('/', [TelegramUserController::class, 'index'])->name('index');
         Route::post('/refresh', [TelegramUserController::class, 'refresh'])->name('refresh');
+        Route::post('/install', [TelegramUserController::class, 'installDependencies'])->name('install');
         Route::get('/all', [TelegramUserController::class, 'downloadAll'])->name('all');
         Route::get('/new', [TelegramUserController::class, 'downloadNew'])->name('new');
     });


### PR DESCRIPTION
## Summary
- install Telegram Python dependencies into a writable storage directory instead of the root home folder
- ensure all Python processes receive the custom site-packages directory through the PYTHONPATH environment variable
- reuse a shared helper for Python process creation to keep consistent environment and working directory handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8282fe5d0832688942e4aa96af508